### PR TITLE
Fix user permissions

### DIFF
--- a/include/access_rules.php
+++ b/include/access_rules.php
@@ -95,9 +95,11 @@
     # Hosts Service view
     $NConf_PERMISSIONS->setURL('modify_item_service.php', FALSE, array('user') );
 
-    # clone
-    $NConf_PERMISSIONS->setURL('clone_host', TRUE, array('user') );
+    # Clone host/service
+    $NConf_PERMISSIONS->setURL('clone_host.php', FALSE, array('user') );
+    $NConf_PERMISSIONS->setURL('clone_host_write2db.php', FALSE, array('user') );
     $NConf_PERMISSIONS->setURL('clone_service.php', FALSE, array('user') );
+    $NConf_PERMISSIONS->setURL('clone_service_write2db.php', FALSE, array('user') );
 
     # Config deployment
     $NConf_PERMISSIONS->setURL('call_file.php', FALSE, array('user') );

--- a/include/access_rules.php
+++ b/include/access_rules.php
@@ -99,6 +99,8 @@
     $NConf_PERMISSIONS->setURL('clone_host', TRUE, array('user') );
     $NConf_PERMISSIONS->setURL('clone_service.php', FALSE, array('user') );
 
+    # Config deployment
+    $NConf_PERMISSIONS->setURL('call_file.php', FALSE, array('user') );
     
 
     # id_wrapper

--- a/include/classes/class.NConf_PERMISSIONS.php
+++ b/include/classes/class.NConf_PERMISSIONS.php
@@ -133,12 +133,14 @@ class NConf_PERMISSIONS{
 
         # check group permission
         if ( empty($GROUPS) OR in_array($this->group, $GROUPS) ){
+            $this->debug .= NConf_HTML::swap_content($URL, "URL", FALSE, TRUE);
+            $this->debug .= NConf_HTML::swap_content($REGEX_OPEN_END, "REGEX_OPEN_END", FALSE, TRUE);
             if ($REGEX_OPEN_END){
-                if ( !preg_match('/^'.preg_quote($URL).'\w*/', $this->current_script) ){
+                if ( !preg_match('/(^|\/)'.preg_quote($URL).'\w*/', $this->current_script) ){
                     return;
                 }
             }else{
-                if ( !preg_match('/^'.preg_quote($URL).'$/', $this->current_script) ){
+                if ( !preg_match('/(^|\/)'.preg_quote($URL).'$/', $this->current_script) ){
                     return;
                 }
             }


### PR DESCRIPTION
This fix corrects some pattern matching for page access permission check, and allow a user to deploy the generated config

Related forum topics:

Contact authentication issue
http://forum.nconf.org/viewtopic.php?f=17&t=856

"users" not allowed to deploy a configuration 
http://forum.nconf.org/viewtopic.php?f=18&t=890

Problems with authentification after upgrade
http://forum.nconf.org/viewtopic.php?f=17&t=883
