### PR TITLE
Fix static file editor

### DIFF
--- a/static_file_editor.php
+++ b/static_file_editor.php
@@ -83,6 +83,7 @@ if ( ($action == "Save") AND (isset($content) AND isset($full_path) ) ){
         $saved = FALSE;
     }else{
         #write to file
+        $content = str_replace("\r\n", "\n", $content); #remove carriage returns
         if ( fwrite($fh, $content) == FALSE){
             # could not write to file
             message($info, "The config directory and all its content must be writable for your webserver user.", "overwrite");


### PR DESCRIPTION
force the editor to save using LF eol, so to not add a carriage return, which can break the software behind the edited files

Related forum topics:

Static config file editor add unexpected carrier returns 
http://forum.nconf.org/viewtopic.php?f=18&t=874
