### PR TITLE
Icon overview on os detail page

### DIFF
--- a/detail.php
+++ b/detail.php
@@ -126,6 +126,9 @@ echo '<div style="width: 500px;" class="relative">';
         }
         array_push($basic_result, $attributes);
     }
+    if ($item_class == "os" and $basic_result[1][attr_value] != "" and is_readable(OS_LOGO_PATH."/".$basic_result[1][attr_value])) {
+        array_push($basic_result, array('friendly_name' => 'overview', 'attr_value' => "<img src=".OS_LOGO_PATH."/".$basic_result[1][attr_value].">"));
+    }
 
     echo table_output($basic_result, $item_class);
 


### PR DESCRIPTION
Icon overview on os detail page

This small addition prints an overview of the icon configured for the selected os in that detail page.
Nice to see directly what the icon looks like, and what its size will be on the statusmap.

BR,
Yannick

Related forum topic:
http://forum.nconf.org/viewtopic.php?f=20&t=866
