### PR TITLE
JSON format error

### DIFF
--- a/include/ajax/json/history.php
+++ b/include/ajax/json/history.php
@@ -141,6 +141,7 @@ while ( $aRow = mysql_fetch_array( $rResult ) )
 }
 $sOutput = substr_replace( $sOutput, "", -1 );
 $sOutput .= '] }';
+$sOutput = str_replace("\\'", "\\\\'", $sOutput);
 
 echo $sOutput;
 


### PR DESCRIPTION
JSON format error

The problem was with the backslash. And this is quite common to have such a character in the action_URL string.

Discovered that some backslashes don't have to be doubled. So the patch above breaks some other strings.
ex:
    "<a href=\"detail.php?id=7054\">Cisco_environment</a>",
Corrected the patch (more accurate to \' pattern):

BR,
Yannick

Related forum topic:
http://forum.nconf.org/viewtopic.php?f=18&t=869
