### PR TITLE
Feature to log the remote ip/hostname to the history

### DIFF
--- a/config.orig/nconf.php
+++ b/config.orig/nconf.php
@@ -124,4 +124,10 @@ define('PASSWD_DISPLAY', 0);
 #
 define('PASSWD_HIDDEN_STRING', "********");
 
+#
+# CONTRIBUTIONS
+#
+# Enable/disable the log of the remote ip/hostname in the nconf history. When activated, the ip (or hostname in case HostnameLookups is set to On in httpd.conf) is appended to the username.
+define('LOG_REMOTE_IP_HISTORY',0);
+
 ?>

--- a/history.php
+++ b/history.php
@@ -137,12 +137,12 @@ if ( ( empty($_GET["show"]) OR $_GET["show"] != "all" ) AND $show_num_rows > "50
 echo '<table id="history" style="width: 100%">';
 echo '<thead>';
 echo '<tr>';
-    echo '<th width="120">When</td>
-            <th width="120">Who</td>
-            <th width="60">Action</td>
-            <th width="100">Object</td>
-            <th width="360">Value</td>
-            <th width="20">ID</td>';
+echo '<th width="120">When</td>
+        <th width="220">Who</td>
+        <th width="60">Action</td>
+        <th width="100">Object</td>
+        <th width="360">Value</td>
+        <th width="20">ID</td>';
 echo '</tr>';
 echo '</thead>';
 echo '<tbody>';

--- a/include/functions.php
+++ b/include/functions.php
@@ -269,6 +269,13 @@ function history_add($action, $name, $value, $fk_id_item = 'NULL', $feature = ''
     }else{
         $user = "unknown";
     }
+    if (LOG_REMOTE_IP_HISTORY == 1){
+        if ( !empty($_SERVER['REMOTE_HOST']) ){
+            $user .= " (".$_SERVER['REMOTE_HOST'].")";
+        }elseif( !empty($_SERVER['REMOTE_ADDR']) ){
+            $user .= " (".$_SERVER['REMOTE_ADDR'].")";
+        }
+    }
     # Feature's
     switch($feature){
         # Resolve assignment looks up the real value behind the id(foreign keys)


### PR DESCRIPTION
Add the remote ip to the user when logging to the history.
This is particulary useful when the user accounts are shared by multiple persons (exemple: "networkadmin" user)
This could be changed to a more sofisticate solution, with an additional history column "remote host/ip".
