### PR TITLE
Handle Apache SHA1 htpasswd format

### DIFF
--- a/bin/lib/NConf/ExportNagios.pm
+++ b/bin/lib/NConf/ExportNagios.pm
@@ -1406,7 +1406,7 @@ sub write_htpasswd_file {
             $userpass = $1;
         } elsif ($userpass =~ /^{SHA1}(.*)/) {
             # Convert to Apache Compatible SHA1 hashing
-            $userpass = encode_base64(pack ("H*", $userpass));
+            $userpass = encode_base64(pack ("H*", $1));
             chomp($userpass);
             $userpass = '{SHA}' . $userpass;
         } else {


### PR DESCRIPTION
Minor patch to ExportNagios.pm to suport SHA1 password hashes in the Apache htpasswd format. Adds an additional requirement for `MIME::Base64` but that should be fairly standard?

~tommy
