### PR TITLE
Update modify_attr_write2db.php

### DIFF
--- a/modify_attr_write2db.php
+++ b/modify_attr_write2db.php
@@ -157,7 +157,7 @@ if(isset($_POST['predef_value'])){
 if(isset($_POST['max_length'])){
     $max_length = $_POST['max_length'];
 }else{
-    $max_length = "";
+    $max_length = "0";
 }
 
 if($_POST['ordering'] != ""){


### PR DESCRIPTION
In OpenSuSE 13.1, when update/add any attribute, because the mysql database  "max_length" field is integer
example:
UPDATE ConfigAttrs SET attr_name = 'register', friendly_name = 'register', description = '', max_length = '', poss_values = '0::1', predef_value = '0', mandatory = 'yes', ordering = '26', visible = 'yes', write_to_conf = 'yes' WHERE id_attr = 231
error:
mysql error:Incorrect integer value: '' for column 'max_length' at row 1
