### PR TITLE
Using rsync 3.1.1 reloads were never executed

### DIFF
--- a/include/modules/deployment/rsync/class.deployment_rsync.php
+++ b/include/modules/deployment/rsync/class.deployment_rsync.php
@@ -34,7 +34,7 @@ class rsync extends NConf_Deployment_Modules
         $run_command = FALSE;
         if ( is_array($status) ){
             foreach ($status AS $output_line){
-                if ( strstr($output_line, "Number of files transferred: ") ){
+                if( preg_match("/Number of (regular )?files transferred: /", $output_line) ){
                     $transferred = explode(":", $output_line);
                     if ( trim($transferred[1]) > 0 ){
                         // files transferred, run command if defined


### PR DESCRIPTION
This is because the output was changed to be `Number of regular files transferred` rather than `Number of files transferred`; the regex is backwards compatible.

We noticed this when we rebuilt our nagios instances from Ubuntu 12.04 (RSync 3.0.9) onto Debian Jessie (RSync 3.1.1)
