### PR TITLE
Add support for newer rsync stats output.

### DIFF
--- a/include/modules/deployment/rsync/class.deployment_rsync.php
+++ b/include/modules/deployment/rsync/class.deployment_rsync.php
@@ -34,7 +34,10 @@ class rsync extends NConf_Deployment_Modules
         $run_command = FALSE;
         if ( is_array($status) ){
             foreach ($status AS $output_line){
-                if ( strstr($output_line, "Number of files transferred: ") ){
+                if ( strstr($output_line, "Number of files transferred: ") ||
+                     strstr($output_line, "Number of created files: ") ||
+                     strstr($output_line, "Number of deleted files: ") ||
+                     strstr($output_line, "Number of regular files transferred: ") ){
                     $transferred = explode(":", $output_line);
                     if ( trim($transferred[1]) > 0 ){
                         // files transferred, run command if defined


### PR DESCRIPTION
For rsync 3.1.1 the output contains:
```
Number of files: 16 (reg: 14, dir: 2)
Number of created files: 0
Number of deleted files: 0
Number of regular files transferred: 1
```

The `reload_command` will be triggered when the number of created, deleted or transferred files is greater than 0.

This PR is an alternative to #35.